### PR TITLE
Update depot-lifecycle-openapi-2.1.0.yaml

### DIFF
--- a/depot-lifecycle-openapi-2.1.0.yaml
+++ b/depot-lifecycle-openapi-2.1.0.yaml
@@ -900,7 +900,7 @@ components:
           - "true"
           type: string
           description: the identifier for this party, often referred to as an EDI
-            Address
+            Address, it is recommended to use the BIC Facility Code for this identifier for container facilities.
           example: DEHAMCMRA
         userCode:
           maxLength: 16


### PR DESCRIPTION
Suggestion on description relating to issue #3 to highlight that the BIC Facility Codes are accepted and recommended for the container facility id.